### PR TITLE
disallow integrated payout addresses

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -2974,16 +2974,20 @@ miner_on_login(json_object *message, client_t *client)
 
     const char *address = json_object_get_string(login);
     uint8_t nt = 0;
-    if (parse_address(address, NULL, &nt, NULL))
+    uint64_t pf = 0;
+    if (parse_address(address, &pf, &nt, NULL))
     {
-        send_validation_error(client,
-                "Invalid address");
+        send_validation_error(client, "Invalid address");
         return;
     }
     if (nt != nettype)
     {
-        send_validation_error(client,
-                "Invalid address network type");
+        send_validation_error(client, "Invalid address network type");
+        return;
+    }
+    if (is_integrated(pf))
+    {
+        send_validation_error(client, "Invalid address type");
         return;
     }
 

--- a/src/xmr.cpp
+++ b/src/xmr.cpp
@@ -120,6 +120,15 @@ int parse_address(const char *input, uint64_t *prefix,
     return XMR_NO_ERROR;
 }
 
+int is_integrated(uint64_t prefix)
+{
+    if (prefix == CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX ||
+            prefix == testnet::CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX ||
+            prefix == stagenet::CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX)
+        return 1;
+    return 0;
+}
+
 int get_block_hash(const unsigned char *input, const size_t in_size,
         unsigned char *output)
 {

--- a/src/xmr.h
+++ b/src/xmr.h
@@ -51,6 +51,7 @@ int get_hashing_blob(const unsigned char *input, const size_t in_size,
         unsigned char **output, size_t *out_size);
 int parse_address(const char *input, uint64_t *prefix,
         uint8_t *nettype, unsigned char *pub_spend);
+int is_integrated(uint64_t prefix);
 int get_block_hash(const unsigned char *input, const size_t in_size,
         unsigned char *output);
 void get_hash(const unsigned char *input, const size_t in_size,


### PR DESCRIPTION
Batched transfers (`transfer_split`) fail with transfers to multiple
integrated addresses so simply disallow them.